### PR TITLE
Annotate deprecated_args decorator to preserve wrapped function type …

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Start a redis via docker (for Redis versions < 8.0):
 
 ``` bash
 docker run -p 6379:6379 -it redis/redis-stack:latest
-
+```
 To install redis-py, simply:
 
 ``` bash

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -1,9 +1,10 @@
 import datetime
 import logging
 import textwrap
+from collections.abc import Callable
 from contextlib import contextmanager
 from functools import wraps
-from typing import Any, Dict, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, TypeVar, Union
 
 from redis.exceptions import DataError
 from redis.typing import AbsExpiryT, EncodableT, ExpiryT
@@ -150,18 +151,21 @@ def warn_deprecated_arg_usage(
     warnings.warn(msg, category=DeprecationWarning, stacklevel=stacklevel)
 
 
+C = TypeVar("C", bound=Callable)
+
+
 def deprecated_args(
     args_to_warn: list = ["*"],
     allowed_args: list = [],
     reason: str = "",
     version: str = "",
-):
+) -> Callable[[C], C]:
     """
     Decorator to mark specified args of a function as deprecated.
     If '*' is in args_to_warn, all arguments will be marked as deprecated.
     """
 
-    def decorator(func):
+    def decorator(func: C) -> C:
         @wraps(func)
         def wrapper(*args, **kwargs):
             # Get function argument names


### PR DESCRIPTION
Fork repo PR for https://github.com/redis/redis-py/pull/3701, to show successful CI checks